### PR TITLE
Fix for users with R and Rstudio installed via `Homebrew`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,6 +11,7 @@ License: MIT + file LICENSE
 LazyLoad: yes
 Packaged: 2017-12-19 00:00:00 UTC-8; kotila
 ByteCompile: yes
+StagedInstall: no
 NeedsCompilation: yes
 Repository: CRAN
 Date/Publication: 2017-12-19 00:00:00


### PR DESCRIPTION
Adding `StagedInstall: no` to `./DESCRIPTION`works around the issue.